### PR TITLE
Adding New Relic monitoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('envloader').load();
+require('newrelic');
 var Conn = require('./services/db.js');
 var Server = require('./services/server.js');
 

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,0 +1,24 @@
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config.defaults.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: ['oam-catalog'],
+  /**
+   * Your New Relic license key.
+   */
+  license_key: 'license key here',
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'info'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hapi-router": "^3.0.1",
     "lodash": "^3.8.0",
     "mongoose": "^4.0.2",
+    "newrelic": "^1.20.0",
     "request": "^2.55.0",
     "s3": "^4.4.0",
     "turf-bbox-polygon": "^1.0.1",


### PR DESCRIPTION
NEW_RELIC_LICENSE_KEY environment variable will need to be set and Heroku add-on will need to be enabled.