### PR TITLE
Api calls cached

### DIFF
--- a/plugins/paginate.js
+++ b/plugins/paginate.js
@@ -4,32 +4,38 @@ var _ = require('lodash');
 
 var pagination = {
   register: function (server, options, next) {
-    var page = 1;
-    var limit = options.limit || 100;
+    var defaultPage = 1;
+    var defaultLimit = options.limit || 100;
     var name = options.name || 'meta';
     var results = options.results || 'results';
+    var requestLimit = defaultLimit;
+    var requestPage = defaultPage;
 
     server.ext('onPreHandler', function (request, reply) {
       if (_.has(request.query, 'page')) {
-        page = _.parseInt(request.query.page);
+        requestPage = _.parseInt(request.query.page);
         request.query = _.omit(request.query, 'page');
+      } else {
+        requestPage = defaultPage;
       }
 
       if (_.has(request.query, 'limit')) {
-        limit = _.parseInt(request.query.limit);
+        requestLimit = _.parseInt(request.query.limit);
         request.query = _.omit(request.query, 'limit');
+      } else {
+        requestLimit = defaultLimit;
       }
 
-      request.page = page;
-      request.limit = limit;
+      request.page = requestPage;
+      request.limit = requestLimit;
 
       return reply.continue();
     });
 
     server.ext('onPreResponse', function (request, reply) {
       var meta = {
-      page: page,
-      limit: limit
+        page: requestPage,
+        limit: requestLimit
       };
 
       if (_.has(request, 'count')) {


### PR DESCRIPTION
Fix for #62, there was a bug in paginate that stores variables of previous requests in `page` and `limit`. cc @scisco 