### PR TITLE
Implemented footprint and bbox transformation tools from EPSG3857 to 4326.

### DIFF
--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -138,9 +138,14 @@ module.exports.addRemoteMeta = function (remoteUri, lastModified, lastSystemUpda
           var payload = JSON.parse(body);
           payload.meta_uri = remoteUri;
 
-          // create a geojson object from footprint and bbox
-          payload.geojson = parse(payload.footprint);
-          payload.geojson.bbox = payload.bbox;
+          if (payload.projection.indexOf('AUTHORITY["EPSG","3857"]') === -1){
+            // create a geojson object from footprint and bbox
+            payload.geojson = parse(payload.footprint);
+            payload.geojson.bbox = payload.bbox;
+          }
+          else {
+            payload.geojson = null
+          }
 
           var query = { uuid: payload.uuid };
           var options = { upsert: true, new: true, select: { uuid: 1 } };

--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -6,6 +6,7 @@ var parse = require('wellknown');
 var bboxPolygon = require('turf-bbox-polygon');
 var Boom = require('boom');
 var Meta = require('../models/meta.js');
+var geotools = require('../utilities/geotools.js')
 
 /**
 * Query Meta model. Implements all protocols supported by /meta endpoint
@@ -144,7 +145,11 @@ module.exports.addRemoteMeta = function (remoteUri, lastModified, lastSystemUpda
             payload.geojson.bbox = payload.bbox;
           }
           else {
-            payload.geojson = null
+            // create a geojson object from footprint and bbox
+            // payload.geojson = null
+            var footprintTransformed =  geotools.transformWktPolygon(3857, 4326, payload.footprint)
+            payload.geojson = parse(footprintTransformed);
+            payload.geojson.bbox = geotools.transformBbox(3857, 4326, payload.bbox);
           }
 
           var query = { uuid: payload.uuid };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "request": "^2.55.0",
     "s3": "^4.4.0",
     "turf-bbox-polygon": "^1.0.1",
-    "wellknown": "^0.3.1"
+    "wellknown": "^0.3.1",
+    "gdal": "0.9.3"
   },
   "devDependencies": {
     "apidoc": "^0.13.1",

--- a/utilities/geotools.js
+++ b/utilities/geotools.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var gdal = require('gdal');
+
+/**
+* tool for transforming spatial reference of footprint in wellknown
+* text format
+*
+* @param {int} numEPSGIn - EPSG code of input reference system
+* @param {int} numEPSGOut - EPSG code of output reference system
+* @param {string} wktFootprint - input footprint in wkt format
+* @return {string} - Transformed footprint in wkt format
+*/
+module.exports.transformWktPolygon = function(numEPSGIn, numEPSGOut, wktFootprint) {
+  var srcIn = gdal.SpatialReference.fromEPSG(numEPSGIn)
+  var srcOut = gdal.SpatialReference.fromEPSG(numEPSGOut)
+
+  var regExp = /[+-]?\d+(\.\d+)?/g;
+  var arrayFootprint = wktFootprint.match(regExp)
+  //console.log(arrayFootprint)
+
+  var ct = new gdal.CoordinateTransformation(srcIn, srcOut);
+  var wktTransformedFootprint = "POLYGON(("
+
+  for(var i = 0; i < arrayFootprint.length; i += 2) {
+    var valueX = parseFloat(arrayFootprint[i])
+    var valueY = parseFloat(arrayFootprint[i+1])
+
+    var transformedPoint = ct.transformPoint(valueX, valueY)
+    //console.log(transformedPoint)
+
+    wktTransformedFootprint += transformedPoint['x'] + ' ' + transformedPoint['y']
+    if(i < arrayFootprint.length - 2) {
+      wktTransformedFootprint += ','
+    }
+  }
+  wktTransformedFootprint = wktTransformedFootprint + "))"
+  return wktTransformedFootprint
+}
+
+/**
+* tool for transforming spatial reference of bounding box in javascript
+* array
+*
+* @param {int} numEPSGIn - EPSG code of input reference system
+* @param {int} numEPSGOut - EPSG code of output reference system
+* @param {array} bboxInArray - Bounding box in javascript array
+* @return {array} Transformed bounding box in array
+*/
+module.exports.transformBbox = function(numEPSGIn, numEPSGOut, bboxInArray) {
+  var srcIn = gdal.SpatialReference.fromEPSG(numEPSGIn)
+  var srcOut = gdal.SpatialReference.fromEPSG(numEPSGOut)
+
+  var originalLT = new Array(bboxInArray[0], bboxInArray[1])
+  var originalRB = new Array(bboxInArray[2], bboxInArray[3])
+
+  var ct = new gdal.CoordinateTransformation(srcIn, srcOut);
+  var ptLT = ct.transformPoint(originalLT[0], originalLT[1])
+  var ptRB = ct.transformPoint(originalRB[0], originalRB[1])
+
+  var bboxTransformed = [ptLT['x'], ptLT['y'], ptRB['x'], ptRB['y']]
+  //console.log(bboxTransformed)
+  return bboxTransformed
+}

--- a/utilities/geotools.js
+++ b/utilities/geotools.js
@@ -51,14 +51,17 @@ module.exports.transformBbox = function(numEPSGIn, numEPSGOut, bboxInArray) {
   var srcIn = gdal.SpatialReference.fromEPSG(numEPSGIn)
   var srcOut = gdal.SpatialReference.fromEPSG(numEPSGOut)
 
-  var originalLT = new Array(bboxInArray[0], bboxInArray[1])
-  var originalRB = new Array(bboxInArray[2], bboxInArray[3])
+  var originalLonMinLatMin = new Array(bboxInArray[0], bboxInArray[1])
+  var originalLonMaxLatMax = new Array(bboxInArray[2], bboxInArray[3])
 
   var ct = new gdal.CoordinateTransformation(srcIn, srcOut);
-  var ptLT = ct.transformPoint(originalLT[0], originalLT[1])
-  var ptRB = ct.transformPoint(originalRB[0], originalRB[1])
+  var transformedLonMinLatMin = ct.transformPoint(originalLonMinLatMin[0], originalLonMinLatMin[1])
+  var transformedLonMaxLatMax = ct.transformPoint(originalLonMaxLatMax[0], originalLonMaxLatMax[1])
 
-  var bboxTransformed = [ptLT['x'], ptLT['y'], ptRB['x'], ptRB['y']]
+  var bboxTransformed = [transformedLonMinLatMin['x'],
+                         transformedLonMinLatMin['y'],
+                         transformedLonMaxLatMax['x'],
+                         transformedLonMaxLatMax['y']]
   //console.log(bboxTransformed)
   return bboxTransformed
 }


### PR DESCRIPTION
In QGIS plugin, EPSG3857 metadata could be uploaded. However, this was causing a problem, because geojson object with 2dsphere indexes don’t accept this projection. 
So, I have inserted a conditional statement in worker.js, to prevent geojson parser from loading these EPSG3857 metadata.
I think we will need to insert some additional statements to re-convert these metadata into EPSG4326 later, but at the moment, null value is set to be inserted into the geojson object. 
Thanks