### PR TITLE
Update - Transformation of footprint and bbox from EPSG3857 to 4326.

### DIFF
--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -138,9 +138,14 @@ module.exports.addRemoteMeta = function (remoteUri, lastModified, lastSystemUpda
           var payload = JSON.parse(body);
           payload.meta_uri = remoteUri;
 
-          // create a geojson object from footprint and bbox
-          payload.geojson = parse(payload.footprint);
-          payload.geojson.bbox = payload.bbox;
+          if (payload.projection.indexOf('AUTHORITY["EPSG","3857"]') === -1){
+            // create a geojson object from footprint and bbox
+            payload.geojson = parse(payload.footprint);
+            payload.geojson.bbox = payload.bbox;
+          }
+          else {
+            payload.geojson = null
+          }
 
           var query = { uuid: payload.uuid };
           var options = { upsert: true, new: true, select: { uuid: 1 } };

--- a/controllers/meta.js
+++ b/controllers/meta.js
@@ -6,6 +6,7 @@ var parse = require('wellknown');
 var bboxPolygon = require('turf-bbox-polygon');
 var Boom = require('boom');
 var Meta = require('../models/meta.js');
+var geotools = require('../utilities/geotools.js')
 
 /**
 * Query Meta model. Implements all protocols supported by /meta endpoint
@@ -144,7 +145,11 @@ module.exports.addRemoteMeta = function (remoteUri, lastModified, lastSystemUpda
             payload.geojson.bbox = payload.bbox;
           }
           else {
-            payload.geojson = null
+            // create a geojson object from footprint and bbox
+            // payload.geojson = null
+            var footprintTransformed =  geotools.transformWktPolygon(3857, 4326, payload.footprint)
+            payload.geojson = parse(footprintTransformed);
+            payload.geojson.bbox = geotools.transformBbox(3857, 4326, payload.bbox);
           }
 
           var query = { uuid: payload.uuid };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "request": "^2.55.0",
     "s3": "^4.4.0",
     "turf-bbox-polygon": "^1.0.1",
-    "wellknown": "^0.3.1"
+    "wellknown": "^0.3.1",
+    "gdal": "0.9.3"
   },
   "devDependencies": {
     "apidoc": "^0.13.1",

--- a/utilities/geotools.js
+++ b/utilities/geotools.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var gdal = require('gdal');
+
+/**
+* tool for transforming spatial reference of footprint in wellknown
+* text format
+*
+* @param {int} numEPSGIn - EPSG code of input reference system
+* @param {int} numEPSGOut - EPSG code of output reference system
+* @param {string} wktFootprint - input footprint in wkt format
+* @return {string} - Transformed footprint in wkt format
+*/
+module.exports.transformWktPolygon = function(numEPSGIn, numEPSGOut, wktFootprint) {
+  var srcIn = gdal.SpatialReference.fromEPSG(numEPSGIn)
+  var srcOut = gdal.SpatialReference.fromEPSG(numEPSGOut)
+
+  var regExp = /[+-]?\d+(\.\d+)?/g;
+  var arrayFootprint = wktFootprint.match(regExp)
+  //console.log(arrayFootprint)
+
+  var ct = new gdal.CoordinateTransformation(srcIn, srcOut);
+  var wktTransformedFootprint = "POLYGON(("
+
+  for(var i = 0; i < arrayFootprint.length; i += 2) {
+    var valueX = parseFloat(arrayFootprint[i])
+    var valueY = parseFloat(arrayFootprint[i+1])
+
+    var transformedPoint = ct.transformPoint(valueX, valueY)
+    //console.log(transformedPoint)
+
+    wktTransformedFootprint += transformedPoint['x'] + ' ' + transformedPoint['y']
+    if(i < arrayFootprint.length - 2) {
+      wktTransformedFootprint += ','
+    }
+  }
+  wktTransformedFootprint = wktTransformedFootprint + "))"
+  return wktTransformedFootprint
+}
+
+/**
+* tool for transforming spatial reference of bounding box in javascript
+* array
+*
+* @param {int} numEPSGIn - EPSG code of input reference system
+* @param {int} numEPSGOut - EPSG code of output reference system
+* @param {array} bboxInArray - Bounding box in javascript array
+* @return {array} Transformed bounding box in array
+*/
+module.exports.transformBbox = function(numEPSGIn, numEPSGOut, bboxInArray) {
+  var srcIn = gdal.SpatialReference.fromEPSG(numEPSGIn)
+  var srcOut = gdal.SpatialReference.fromEPSG(numEPSGOut)
+
+  var originalLT = new Array(bboxInArray[0], bboxInArray[1])
+  var originalRB = new Array(bboxInArray[2], bboxInArray[3])
+
+  var ct = new gdal.CoordinateTransformation(srcIn, srcOut);
+  var ptLT = ct.transformPoint(originalLT[0], originalLT[1])
+  var ptRB = ct.transformPoint(originalRB[0], originalRB[1])
+
+  var bboxTransformed = [ptLT['x'], ptLT['y'], ptRB['x'], ptRB['y']]
+  //console.log(bboxTransformed)
+  return bboxTransformed
+}

--- a/utilities/geotools.js
+++ b/utilities/geotools.js
@@ -51,14 +51,17 @@ module.exports.transformBbox = function(numEPSGIn, numEPSGOut, bboxInArray) {
   var srcIn = gdal.SpatialReference.fromEPSG(numEPSGIn)
   var srcOut = gdal.SpatialReference.fromEPSG(numEPSGOut)
 
-  var originalLT = new Array(bboxInArray[0], bboxInArray[1])
-  var originalRB = new Array(bboxInArray[2], bboxInArray[3])
+  var originalLonMinLatMin = new Array(bboxInArray[0], bboxInArray[1])
+  var originalLonMaxLatMax = new Array(bboxInArray[2], bboxInArray[3])
 
   var ct = new gdal.CoordinateTransformation(srcIn, srcOut);
-  var ptLT = ct.transformPoint(originalLT[0], originalLT[1])
-  var ptRB = ct.transformPoint(originalRB[0], originalRB[1])
+  var transformedLonMinLatMin = ct.transformPoint(originalLonMinLatMin[0], originalLonMinLatMin[1])
+  var transformedLonMaxLatMax = ct.transformPoint(originalLonMaxLatMax[0], originalLonMaxLatMax[1])
 
-  var bboxTransformed = [ptLT['x'], ptLT['y'], ptRB['x'], ptRB['y']]
+  var bboxTransformed = [transformedLonMinLatMin['x'],
+                         transformedLonMinLatMin['y'],
+                         transformedLonMaxLatMax['x'],
+                         transformedLonMaxLatMax['y']]
   //console.log(bboxTransformed)
   return bboxTransformed
 }


### PR DESCRIPTION
I have picked up some of my samples and checked the results again, but do you think I should test more?
(Please refer to #82 for more details.)
As you can see, there are some small errors, but I think these are kind of normal, since these data are reprojected twice. (from EPSG4326 to EPSG3857, and EPSG3857 to 4326).

At the moment, I've only worked on these two spatial reference systems (4326 and 3857).
 
The results are:
Sample A
Original: [-80.2637534,-0.3615311,-80.2600808,-0.3579259]
EPSG3857: [-8934920.162,-40245.735,-8934511.303,-39844.39]
Re-transformed into EPSG4326: [-80.2637534391227,-0.3615311896290982,-80.26008059623517,-0.3579259172117474]

Sample B
Original: [106.6775336,-6.3750926,106.9853819,-6.0660647]
EPSG3857: [11875288.724,-711198.264,11909555.826,-676477.444]
Re-transformed into EPSG4326:[106.67753364101407,-6.375604505049481,106.98536025570489,-6.065538902610929]

Sample C
Original: [106.6859743,-6.3734208,106.9745342,-6.0798858]
EPSG3857: [11876228.333,-710959.493,11908346.772,-678083.545
Re-transformed into EPSG4326: [106.68597429227204,-6.373472849916916,106.97449913882963,-6.079885790592785]
